### PR TITLE
Add post copy callbacks if defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,19 @@ Copies a directory with files recursively into a destination folder.
 $files = Dir::copy('my/dir',       // A string path of an array of string paths
     'my/destination',              // A destination path (string only)
     [
-        'mode'           => 0755,  // Mode used for directory creation
-        'childsOnly'     => false, // Copies the file inside 'my/dir' if `true`, otherwise `dir` will be
-                                   // added as the root directory.
-        'followSymlinks' => true,  // Follows Symlinks
-        'recursive'      => true   // Scans recursively
+        'mode'               => 0755,  // Mode used for directory creation
+        'childsOnly'         => false, // Copies the file inside 'my/dir' if `true`, otherwise `dir` will be
+                                       // added as the root directory.
+        'followSymlinks'     => true,  // Follows Symlinks
+        'recursive'          => true,  // Scans recursively
+        'fileCopiedCallback' => {callable},
+        'dirCopiedCallback'  => {callable},
     ]
 );
 ```
+
+If callbacks are passed in, the appropriate callback is called after copying a
+file or directory.  The final path of the item is passed to the callback.
 
 ## `Dir::remove()`
 


### PR DESCRIPTION
This PR adds the support for `fileCopiedCallback` and `dirCopiedCallback` options to `Dir::copy()`. After a file or directory is copied, the appropriate callback is called with the final path of the item copied. Anything that's considered `callable` could be passed as the callback.
## My Use Case

I'm working on a project which copies a source directory of files to a destination. Some of these files are images and post copy, I'd like to perform actions on them such as resizing and optimizing.
## Example usage

``` php
Dir::copy($source->getPath(), $destination->getPath(), array(
    'mode' => 0755,
    'childsOnly' => true,
    'recursive' => true,
    'dirCopiedCallback' => function($path) {
        // Example of a function passed as a callback
        echo "\nDirectory copied: " . $path;
    },
    'fileCopiedCallback' => `MyNamespace\MyClass::fileCopied',
));
```

``` php
namespace MyNamespace;

class MyClass
{
    /**
    * Use a method as the callback instead of a function
    *
    * @param string $path The file of the copied file
    **/
    public static function fileCopied($path)
    {
        echo "\nFile copied: " . $path;
    }
}

------

I think this PR should have minimal impact and wouldn't break backwards compatibility. Please let me know if you have any questions/concerns etc with this feature addition and whether you'd consider adding it to the project.

Thanks!
```
